### PR TITLE
feat: redirect index route GET requests to  `/app`

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10.13-slim
 ENV PYTHONUNBUFFERED True
 ENV APP_HOME /app
 WORKDIR $APP_HOME

--- a/api/api.py
+++ b/api/api.py
@@ -33,7 +33,7 @@ entitlement_states = [
 ]
 
 # NOTE: we could just make this an SPA...then we don't need a server at all
-@app.route(f"/app")
+@app.route("/app")
 def entitlements():
     try:
         add_request_context_to_log(str(uuid.uuid4()))
@@ -54,7 +54,7 @@ def entitlements():
         logger.error(e)
         return {"error": "Loading failed"}, 500
 
-@app.route(f"/app/account/<account_id>")
+@app.route("/app/account/<account_id>")
 def show_account(account_id):
     try:
         add_request_context_to_log(str(uuid.uuid4()))
@@ -261,6 +261,11 @@ def handle_subscription_message():
 @app.route("/alive")
 def alive():
     return "", 200
+
+# redirects `/` -> `/app`
+@app.route("/", methods=["GET"])
+def redirect_index():
+    return redirect(url_for('app'))
 
 
 if __name__ == "__main__":

--- a/api/api.py
+++ b/api/api.py
@@ -39,7 +39,7 @@ def entitlements():
         add_request_context_to_log(str(uuid.uuid4()))
         state = request.args.get('state', "ACTIVATION_REQUESTED")
         page_context = {}
-        logger.debug("loading index")
+        logger.debug("loading app")
         state = request.args.get("state", "ACTIVATION_REQUESTED")
         if state not in entitlement_states:
             entitlement_response = procurement_api.list_entitlements()
@@ -265,6 +265,7 @@ def alive():
 # redirects `/` -> `/app`
 @app.route("/", methods=["GET"])
 def redirect_index():
+    logger.debug("loading '/' index, redirects to '/app'")
     return redirect(url_for('app'))
 
 

--- a/api/api.py
+++ b/api/api.py
@@ -2,7 +2,7 @@ import base64
 import os
 import json
 import uuid
-from flask import request, Flask, render_template
+from flask import request, Flask, render_template, redirect, url_for
 from middleware import logger, add_request_context_to_log
 import traceback
 

--- a/api/api.py
+++ b/api/api.py
@@ -266,7 +266,7 @@ def alive():
 @app.route("/", methods=["GET"])
 def redirect_index():
     logger.debug("loading '/' index, redirects to '/app'")
-    return redirect(url_for('app'))
+    return redirect(url_for('entitlements'))
 
 
 if __name__ == "__main__":

--- a/api/api.py
+++ b/api/api.py
@@ -269,4 +269,8 @@ def redirect_index():
     return redirect("/app")
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))
+    app.run(
+        debug=os.environ.get("LOG_LEVEL", "info")=="debug",
+        host="0.0.0.0",
+        port=int(os.environ.get("PORT", 8080))
+    )

--- a/api/api.py
+++ b/api/api.py
@@ -2,7 +2,7 @@ import base64
 import os
 import json
 import uuid
-from flask import request, Flask, render_template, redirect, url_for
+from flask import request, Flask, render_template, redirect
 from middleware import logger, add_request_context_to_log
 import traceback
 
@@ -266,8 +266,7 @@ def alive():
 @app.route("/", methods=["GET"])
 def redirect_index():
     logger.debug("loading '/' index, redirects to '/app'")
-    return redirect(url_for('entitlements'))
-
+    return redirect("/app")
 
 if __name__ == "__main__":
     app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.2
+Flask==2.3.3
 gunicorn==20.1.0
 google-cloud-pubsub==2.18.0
 pg8000==1.24.0
@@ -9,3 +9,4 @@ ratelimit==2.2.1
 backoff==2.1.2
 dynaconf==3.1.9
 pyjwt[crypto]==2.3.0
+Werkzeug==2.3.7

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,4 +9,3 @@ ratelimit==2.2.1
 backoff==2.1.2
 dynaconf==3.1.9
 pyjwt[crypto]==2.3.0
-Werkzeug==2.3.7


### PR DESCRIPTION
## Problem
When navigating to the "root" index route from a browser, A "Not Found" page is returned:
<img width="813" alt="image" src="https://github.com/talon-one/doit-easily-marketplace/assets/6689688/32eeba1f-9b8a-4472-9538-2f2c15c4aca8">

This is confusing and quite alarming for the users who aren't aware / used to navigate to the `/app` to reach the UI

## Solution
Redirect `GET` requests to the `/app` route. It might have a conflict in the future if we ever think of doing more than the current offering of this little tool, but for now - it's the quickest and minimum harm to go with

## Extras
Cleaned up a tiny bit some parts of the code + upgraded some dependencies (some due to a necessity some others just for quality of life):
 - d2bfd40f1636c1f34cda680ca4668306885dda2b - updated minor version of underlying image of python to resolve some known vulnerabilities
 - 3312aa83dbdbf53dc601c7024bae110a9259f8d6 - upgraded Flask to latest minor version ([@2.3.3](https://github.com/pallets/flask/releases/tag/2.3.3))
   - which also fixes [this problem](https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr) which is about dependency versions mismatch
 - c87c58112181134d41ff6f0dead8a583fed8435b - allowing to turn off debug mode; the flask sever's debug mode now depends on the env var `LOG_LEVEL`
 
 Already compiled and pushed this code to the "live" environment, feel free to check https://doit-easily-dvt2mynkrq-uw.a.run.app/ and see the redirection in action 🚀 
