### PR TITLE
feat: removing reference to managed DNS zone, which is not needed.

### DIFF
--- a/docs/terraform/app_deploy/loadbalancer.tf
+++ b/docs/terraform/app_deploy/loadbalancer.tf
@@ -1,22 +1,6 @@
-# Get the managed DNS zone
-
-data "google_dns_managed_zone" "dns_zone" {
-  name     = var.managed_zone_name
-  project = var.managed_zone_project
-}
-
 resource "google_compute_global_address" "external_ip" {
   name     = var.external_ip_name
 }
-# Add the IP to the DNS
-resource "google_dns_record_set" "api" {
-  name         = "${var.domain}."
-  type         = "A"
-  ttl          = 300
-  managed_zone = data.google_dns_managed_zone.dns_zone.name
-  rrdatas      = [google_compute_global_address.external_ip.address]
-}
-
 resource "google_compute_url_map" "url_map" {
   name            = "api-lb-url-map"
   default_service = module.api-lb.backend_services["default"].self_link


### PR DESCRIPTION
## What? 
To create managed DNS zone for Talon.one we need to not use all googe Nameservers Shard. 
We currently occupy whole 5 shards, and in case of marketplace.talon.one without sens, as the address is resolved based on AWS DNS record (`marketplace.talon.one.	300	IN	A	34.36.238.156`) and the managed zone in GCP Cloud DNS is not used.

## Why? 
Limitations of google means we need one accessible zone. 

## How? 
By removing the not used marketplace.talon.one from GCP we will be able to reuse the google DNS shards.

